### PR TITLE
fix(firebase_images): Handle image not found in firebase and keep images when switch of order

### DIFF
--- a/src/models/Module.ts
+++ b/src/models/Module.ts
@@ -101,8 +101,13 @@ export class Module {
       this.image = newRef;
     }
 
-    // Check if we need to delete image
-    if (this.image == "" && originModule && this.image !== originModule.image) {
+    // Check if we need to delete image, so if the new image is empty and the origin part is the same but with an image
+    if (
+      this.image == "" &&
+      originModule &&
+      this.image !== originModule.image &&
+      this.title === originModule.title
+    ) {
       // Delete the image from firebase
       await dataStore.deleteFileFromFirebase(originModule.image);
     }

--- a/src/models/ModulePart.ts
+++ b/src/models/ModulePart.ts
@@ -81,8 +81,13 @@ export class ModulePart {
       this.image = newRef;
     }
 
-    // Check if we need to delete image
-    if (this.image == "" && originPart && this.image !== originPart.image) {
+    // Check if we need to delete image, so if the new image is empty and the origin part is the same but with an image
+    if (
+      this.image == "" &&
+      originPart &&
+      this.image !== originPart.image &&
+      this.subtitle === originPart.subtitle
+    ) {
       // Delete the image from firebase
       await dataStore.deleteFileFromFirebase(originPart.image);
     }

--- a/src/models/ModulePartElement.ts
+++ b/src/models/ModulePartElement.ts
@@ -41,8 +41,13 @@ export class ModulePartElement {
       this.image = newRef;
     }
 
-    // Check if we need to delete image
-    if (this.image == "" && originElement && this.image !== originElement.image) {
+    // Check if we need to delete image, so if the new image is empty and the origin element is the same but with an image
+    if (
+      this.image == "" &&
+      originElement &&
+      this.image !== originElement.image &&
+      this.text === originElement.text
+    ) {
       // Delete the image from firebase
       await dataStore.deleteFileFromFirebase(originElement.image);
     }

--- a/src/stores/data.ts
+++ b/src/stores/data.ts
@@ -419,27 +419,45 @@ export const useDataStore = defineStore("dataStore", {
         const modulePart = module.parts[+route.params.part];
         const modulePartElement = modulePart.elements[+route.params.elt];
         if (modulePartElement.file) {
+          // If there is a file we get the url of the blob
           url = URL.createObjectURL(modulePartElement.file);
         } else if (modulePartElement.image !== "") {
-          url = await getDownloadURL(ref(storage, modulePartElement.image));
+          // If there is an image we get the url of the image from firebase
+          url = await getDownloadURL(ref(storage, modulePartElement.image)).catch((error) => {
+            console.error(error);
+            return "";
+          });
         } else {
+          // Else we display nothing
           url = "";
         }
       } else if ("part" in route.params) {
         const modulePart = module.parts[+route.params.part];
         if (modulePart.file) {
+          // If there is a file we get the url of the blob
           url = URL.createObjectURL(modulePart.file);
         } else if (modulePart.image !== "") {
-          url = await getDownloadURL(ref(storage, modulePart.image));
+          // If there is an image we get the url of the image from firebase
+          url = await getDownloadURL(ref(storage, modulePart.image)).catch((error) => {
+            console.error(error);
+            return "";
+          });
         } else {
+          // Else we display nothing
           url = "";
         }
       } else {
         if (module.file) {
+          // If there is a file we get the url of the blob
           url = URL.createObjectURL(module.file);
         } else if (module.image !== "") {
-          url = await getDownloadURL(ref(storage, module.image));
+          // If there is an image we get the url of the image from firebase
+          url = await getDownloadURL(ref(storage, module.image)).catch((error) => {
+            console.error(error);
+            return "";
+          });
         } else {
+          // Else we display nothing
           url = "";
         }
       }


### PR DESCRIPTION
# Description

What are changes related to ?
Fix finally the bug of deleted images when switching order of content in the modules
Doesn't make an error when the image is not found in firebase

# Tests

How has it been tested ?

- [X] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other
